### PR TITLE
Add If Clause in Workshop Container

### DIFF
--- a/feminnovate-frontend/src/components/WorkshopContainer.jsx
+++ b/feminnovate-frontend/src/components/WorkshopContainer.jsx
@@ -16,26 +16,28 @@ const WorkshopContainer = ( props ) => {
         navigate(`/events/${props.data.id}`);
     }
 
-    
-    return (
-        <div 
-            className="w-[100%] flex items-center justify-center 
-                border-2 border-grey rounded-2xl cursor-pointer 
-                py-20 flex-col
-                hover:bg-grey hover:bg-opacity-30 bg-blue bg-opacity-25" 
-            onClick={redirectToWorkshopDetails}>
-            <img src={props.data.organizer.picture} className="w-36 h-auto"/>
-            <span className={`${styles.subheading2} mt-4 text-center`}>{props.data.title}</span>
-            <div className="flex flex-row items-center mt-2">
-                <img src={calendar} className="mr-1.5"/>
-                <span className={`${styles.subheading5} text-[16px]`}>{parseDate(props.data.start_time)} - {parseDate(props.data.end_time)}</span>
+    if (props.data.organizer) {
+        return (
+            <div 
+                className="w-[100%] flex items-center justify-center 
+                    border-2 border-grey rounded-2xl cursor-pointer 
+                    py-20 flex-col
+                    hover:bg-grey hover:bg-opacity-30 bg-blue bg-opacity-25" 
+                onClick={redirectToWorkshopDetails}>
+                <img src={props.data.organizer.picture} className="w-36 h-auto"/>
+                <span className={`${styles.subheading2} mt-4 text-center`}>{props.data.title}</span>
+                <div className="flex flex-row items-center mt-2">
+                    <img src={calendar} className="mr-1.5"/>
+                    <span className={`${styles.subheading5} text-[16px]`}>{parseDate(props.data.start_time)} - {parseDate(props.data.end_time)}</span>
+                </div>
+                <div className="flex flex-row items-center mt-2">
+                    <img src={location} className="mr-1.5"/>
+                    <span className={`${styles.subheading5} text-[16px]`}>{props.data.location}</span>
+                </div>
             </div>
-            <div className="flex flex-row items-center mt-2">
-                <img src={location} className="mr-1.5"/>
-                <span className={`${styles.subheading5} text-[16px]`}>{props.data.location}</span>
-            </div>
-        </div>
-    )
+        )
+    }
+    return null;
 }
 
 export default WorkshopContainer;


### PR DESCRIPTION
Frontend dashboard seems to break because the `WorkshopContainer` objects are rendered without having the props data inserted yet.

A quickfix for now is to add an `if-clause` to only render the `WorkshopContainer` if the `props.data.organizer` is present inside the data. This is to prevent displaying an undefined image URL which breaks the frontend.